### PR TITLE
disable edr check in selection

### DIFF
--- a/src/jobs/robot.groovy
+++ b/src/jobs/robot.groovy
@@ -408,7 +408,7 @@ try {
             shell("$robotWrapper $agreement $defaultArgs $params")
             shell("$robotWrapper $selection -A robot_tests_arguments/framework_selection.txt $params")
             shell("$robotWrapper -o auction_short_framework_output.xml -s auction -A robot_tests_arguments/framework_selection.txt $params")
-            shell("$robotWrapper -o qualification_framework_output.xml -s qualification -A robot_tests_arguments/framework_selection.txt \$EDR_QUALIFICATION $params")
+            shell("$robotWrapper -o qualification_framework_output.xml -s qualification -A robot_tests_arguments/framework_selection.txt $params")
             shell("$robotWrapper -o contract_framework_output.xml -s contract_signing -A robot_tests_arguments/framework_selection.txt $params")
             shell("$robotWrapper -o contract_management_framework_output.xml -s contract_management -A robot_tests_arguments/framework_selection.txt $params")
             shell(shellRebot)


### PR DESCRIPTION
прибрати тест на перевірку наявності справки з ЄДР під час кваліфікації в 2 етапі рамок, вона там не додається згідно бізнес логіки, наслідок - зайві 10 хв тест намагається перевірити її наявність і ніколи не виконується