### PR TITLE
put branch without criteria to run tests on staging env

### DIFF
--- a/src/jobs/robot.groovy
+++ b/src/jobs/robot.groovy
@@ -149,7 +149,7 @@ try {
                     "DS_REGEXP": "^https?:\\/\\/public-docs(?:-staging)?\\.prozorro\\.gov\\.ua\\/get\\/([0-9A-Fa-f]{32})",
                 ],
                 cron: "0 4 * * *",
-                branch: "master",
+                branch: "env_var",
                 concurrentBuild: false,
                 edr: true,
                 dfs: false


### PR DESCRIPTION
Було оновлена master автотестів, у зв`язку з проведенням закупівлі ДП, але функціонал критеріїв все ще не задеплоїли на на staging середовище, тмоу типчасово звмінюємо гілку з якої будемо запскати автотести на staging на гілку без функціоналу критеріїв