### PR TITLE
split framework log into two parts

### DIFF
--- a/src/jobs/robot.groovy
+++ b/src/jobs/robot.groovy
@@ -100,6 +100,7 @@ def defaultEnv_dfs() {
 String shellBuildout = "sleep \$((RANDOM % 600))\npython2 bootstrap.py\nbin/buildout -N buildout:always-checkout=force\nbin/develop update -f"
 String shellPhantom  = "sed -r -i 's/browser: *(chrome|firefox)/browser:  PhantomJS/gi' op_robot_tests/tests_files/data/users.yaml"
 String shellRebot    = "robot_wrapper bin/rebot -o test_output/output.xml -l test_output/log.html -r test_output/report.html -R test_output/*.xml"
+String shellRebot_selection = "robot_wrapper bin/rebot -o test_output/output.xml -l test_output/Selection_log.html -r test_output/report.html -R test_output/*.xml"
 String robotWrapper  = "robot_wrapper bin/op_tests --consolecolors on "
 String openProcedure = "-o base_output.xml -s openProcedure"
 String auction       = "-o auction_output.xml -s auction_full"
@@ -116,6 +117,10 @@ String cancellation = "-o cancellation_output.xml -s cancellation"
 String fast_auction = "-v submissionMethodDetails:\"new-auction;quick(mode:fast-auction)\""
 String priceQuotation = "-o priceQuotation_output.xml -s priceQuotationProcedure"
 String old_auction = "-o old_auction_output.xml -s auction_long"
+String selection_auction_short = "-o auction_short_selection_output.xml -s auction"
+String selection_qualification = "-o qualification_selection_output.xml -s qualification"
+String selection_contractsign = "-o contract_selection_output.xml -s contract_signing"
+String selection_contractmanagement = "-o contract_management_selection_output.xml -s contract_management"
 
 def remoteToken = null
 try {
@@ -329,6 +334,7 @@ try {
         environmentVariables defaultEnv()
 
         String defaultArgs = "-A robot_tests_arguments/framework_agreement_full.txt"
+        String selectionArgs = "-A robot_tests_arguments/framework_selection_full.txt"
 
         steps {
             shell(shellBuildout)
@@ -338,12 +344,13 @@ try {
             shell("$robotWrapper $qualification $defaultArgs \$EDR_QUALIFICATION \$DFS_QUALIFICATION $params")
             shell("$robotWrapper $contractsign $defaultArgs $params")
             shell("$robotWrapper $agreement $defaultArgs $params")
-            shell("$robotWrapper $selection -A robot_tests_arguments/framework_selection_full.txt $fast_auction $params")
-            shell("$robotWrapper -o auction_short_framework_output.xml -s auction -A robot_tests_arguments/framework_selection_full.txt $params")
-            shell("$robotWrapper -o qualification_framework_output.xml -s qualification -A robot_tests_arguments/framework_selection_full.txt $params")
-            shell("$robotWrapper -o contract_framework_output.xml -s contract_signing -A robot_tests_arguments/framework_selection_full.txt $params")
-            shell("$robotWrapper -o contract_management_framework_output.xml -s contract_management -A robot_tests_arguments/framework_selection_full.txt $params")
             shell(shellRebot)
+            shell("$robotWrapper $selection $selectionArgs $fast_auction $params")
+            shell("$robotWrapper $selection_auction_short $selectionArgs $params")
+            shell("$robotWrapper $selection_qualification $selectionArgs $params")
+            shell("$robotWrapper $selection_contractsign $selectionArgs $params")
+            shell("$robotWrapper $selection_contractmanagement $selectionArgs $params")
+            shell(shellRebot_selection)
         }
     }
 


### PR DESCRIPTION
split framework log into two parts to avoid rewriting logs of same suites execited twice (it is happens because of same name of suite)